### PR TITLE
Cleanup: Include what you use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-Wall -Iinclude -std=c11 -O0 -g
+CFLAGS=-Wall -std=c11 -O0 -g
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 HDRS=$(wildcard include/*.h)

--- a/include/peinfo.h
+++ b/include/peinfo.h
@@ -1,11 +1,6 @@
 /* SPDX-License-Identifier: MIT */
 
 #include <stdio.h>
-#include <stdlib.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/stat.h>
-#include <sys/mman.h>
 
 enum {
   FMT_NONE = 0,

--- a/main.c
+++ b/main.c
@@ -1,7 +1,14 @@
 /* SPDX-License-Identifier: MIT */
 
-#include "pe.h"
-#include "peinfo.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+#include "include/pe.h"
+#include "include/peinfo.h"
 
 static void print_fhdr(FILE *stream, IMAGE_FILE_HEADER *fhdr)
 {

--- a/utils.c
+++ b/utils.c
@@ -1,6 +1,9 @@
 /* SPDX-License-Identifier: MIT */
 
-#include "peinfo.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "include/peinfo.h"
 
 static char *format_str(char *buf, size_t size, void *value, int format)
 {


### PR DESCRIPTION
Following a code cleanliness principle for files to be generally parseable without the context of a build file.
There's no reason to need the -Iinclude flag either, so use repo-root-relative paths for includes.

Thanks for the EDK2 GDB debugging blog :)